### PR TITLE
Update OpenAPI download instructions to use JSON format

### DIFF
--- a/documentation/modules/ROOT/pages/design-apis.adoc
+++ b/documentation/modules/ROOT/pages/design-apis.adoc
@@ -58,7 +58,7 @@ image::api-designer-sample-updated.png[]
 . The changes made are now visible on the main screen. 
 +
 image::api-designer-sample-edit-complete.png[]
-* The OpenAPI specification is now ready to be downloaded. Click on the _down arrow_ button adjacent to *Save As..* and then choose *Save as YAML* button found on top-right of the page. The file gets saved automatically in the *Downloads folder* of your computer.
+* The OpenAPI specification is now ready to be downloaded. Click on the _down arrow_ button adjacent to *Save As..* and then choose *Save as JSON* button found on top-right of the page. The file gets saved automatically in the *Downloads folder* of your computer.
 +
 image::api-download-as-yaml.png[]
 * The Product Catalog OpenAPI spec is ready to be governed with a Service Registry.


### PR DESCRIPTION
This change updates the tutorial instructions to guide users to download the OpenAPI specification in JSON format rather than YAML.

Reasons for the change:
- The tools and platforms used in the tutorial have shown better compatibility with the JSON representation of the OpenAPI spec.
- Users encountered issues when using the YAML format, such as difficulties with the AutoDetect feature and loading the "Documentation" tab of the API on the platform (tried and tested).

To ensure a smooth and error-free experience for users following the tutorial, it's essential to guide them towards the JSON format.