### PR TITLE
Fix hard-coded rhpd URL in m4

### DIFF
--- a/documentation/modules/ROOT/pages/manage-apis.adoc
+++ b/documentation/modules/ROOT/pages/manage-apis.adoc
@@ -181,7 +181,7 @@ image::apim-promote-prod.png[]
 
 == Create an Application for the default account
 
-. Navigate to https://3scale-%USERID%-admin.apps.cluster-vxhmd.sandbox1011.opentlc.com/buyers/accounts[Audience section^, window=3scale] of 3scale from the the top menu bar
+. Navigate to https://3scale-%USERID%-admin.%SUBDOMAIN%/buyers/accounts[Audience section^, window=3scale] of 3scale from the the top menu bar
 +
 image:apim-audeince-menu.png[] 
 . You will be shown the *Accounts > Listing* page showing a default *Developer* account that has already been created.


### PR DESCRIPTION
Fixed a hardcoded rhpd URL in the m4 docs.